### PR TITLE
FC-1056: making actions configurable

### DIFF
--- a/cmd/git-security/api/api.go
+++ b/cmd/git-security/api/api.go
@@ -203,6 +203,8 @@ func NewFiberApp(
 	v1.Post("/repos/action/allows-force-pushes", a.AllowsForcePushes)
 	v1.Post("/repos/action/dismisses-stale-reviews", a.DismissesStaleReviews)
 	v1.Post("/repos/action/required-approving-review-count", a.RequiredApprovingReviewCount)
+	v1.Post("/repos/action/requires-code-owner-reviews", a.RequiresCodeOwnerReviews)
+	v1.Post("/repos/action/requires-commit-signatures", a.RequiresCommitSignatures)
 	v1.Post("/repos/action/requires-conversation-resolution", a.RequiresConversationResolution)
 	v1.Post("/repos/action/repo-owner", a.AddRepoOwner)
 	v1.Post("/repos/action/requires-pr", a.RequiresPR)

--- a/cmd/git-security/github/repository.go
+++ b/cmd/git-security/github/repository.go
@@ -215,9 +215,21 @@ func (ghi *GitHubImpl) UpdateBranchProtectionRule(branchProtectionRuleID, field 
 		if v, ok := value.(bool); ok {
 			input.DismissesStaleReviews = githubv4.NewBoolean(githubv4.Boolean(v))
 		}
+	case "RequiresCodeOwnerReviews":
+		if v, ok := value.(bool); ok {
+			input.RequiresCodeOwnerReviews = githubv4.NewBoolean(githubv4.Boolean(v))
+		}
 	case "RequiresConversationResolution":
 		if v, ok := value.(bool); ok {
 			input.RequiresConversationResolution = githubv4.NewBoolean(githubv4.Boolean(v))
+		}
+	case "RequiresCommitSignatures":
+		if v, ok := value.(bool); ok {
+			input.RequiresCommitSignatures = githubv4.NewBoolean(githubv4.Boolean(v))
+		}
+	case "IsAdminEnforced":
+		if v, ok := value.(bool); ok {
+			input.IsAdminEnforced = githubv4.NewBoolean(githubv4.Boolean(v))
 		}
 	case "AllowsForcePushes":
 		if v, ok := value.(bool); ok {
@@ -226,10 +238,6 @@ func (ghi *GitHubImpl) UpdateBranchProtectionRule(branchProtectionRuleID, field 
 	case "AllowsDeletions":
 		if v, ok := value.(bool); ok {
 			input.AllowsDeletions = githubv4.NewBoolean(githubv4.Boolean(v))
-		}
-	case "IsAdminEnforced":
-		if v, ok := value.(bool); ok {
-			input.IsAdminEnforced = githubv4.NewBoolean(githubv4.Boolean(v))
 		}
 	}
 

--- a/cmd/git-security/ui/common-functions.js
+++ b/cmd/git-security/ui/common-functions.js
@@ -6,6 +6,25 @@ export const showConfirmationDialog = (message) => {
     })
 }
 
+export const actionsConfirmationDialog = async (message) => {
+    try {
+    await ElMessageBox({
+      message: message,
+      showCancelButton: true,
+      showConfirmButton: true,
+      distinguishCancelAndClose: true,
+      confirmButtonText: 'Enable',
+      cancelButtonText: 'Disable',
+      type: 'warning',
+    });
+    return true;
+  } catch (action) {
+    if (action == 'cancel') {
+      return false; // Return false when Disable is clicked
+    }
+  }
+}
+
 export const showNotification = (status) => {
   if (status == "success") {
     ElNotification({


### PR DESCRIPTION
## Description

The actions earlier were hardcoded, now the actions are configurable. The user can enable or disable the action as per their requirement. And the change will be immediately done on the server side and also will be visible on the git-security application

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change was required to give user the flexibility to perform the actions. They may or may not require to enable an action always, giving them the flexibility to enable or disable the action makes it easier for them. For example for one of the branch protection rule that is required number of approvers the user can choose the number of approvers they would want starting from 0 to 6.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
All the changes have been tested locally and each branch protection setting was tested with the change by enabling and disabling them, checking if the changes were done on the github server side and also checking if changes were visible on the dashboard as well

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
