### PR TITLE
FC-1084: Fixing multiple reloads while updating multiple rows

### DIFF
--- a/cmd/git-security/api/column.go
+++ b/cmd/git-security/api/column.go
@@ -23,7 +23,7 @@ func (a *api) GetColumns(c *fiber.Ctx) error {
 		return err
 	}
 	defer cursor.Close(a.ctx)
-	var columns []config.Column
+	columns := []config.Column{}
 	if err := cursor.All(a.ctx, &columns); err != nil {
 		return err
 	}

--- a/cmd/git-security/api/custom.go
+++ b/cmd/git-security/api/custom.go
@@ -20,7 +20,7 @@ func (a *api) GetCustoms(c *fiber.Ctx) error {
 		return err
 	}
 	defer cursor.Close(a.ctx)
-	var customs []config.Custom
+	customs := []config.Custom{}
 	if err := cursor.All(a.ctx, &customs); err != nil {
 		return err
 	}

--- a/cmd/git-security/ui/pages/repos/index.vue
+++ b/cmd/git-security/ui/pages/repos/index.vue
@@ -96,6 +96,10 @@ const fetchRepos = () => {
         [TableV2SortOrder.ASC]
       );
       repos_table.originalData = repos_table.data;
+      repos_table.dataMap.clear();
+      for (let i = 0; i < repos_table.originalData.length; i++) {
+        repos_table.dataMap.set(repos_table.originalData[i].id, i);
+      }
       repos_table_search.text = "";
       repos_table.selected.clear();
       lastCheckboxCheckedIndex = -1;
@@ -345,7 +349,8 @@ const repos_table = reactive({
   selectedDeviceID: null,
   rowKey: "id",
   columns: getDefaultColumns(),
-  originalData: [],
+  dataMap: new Map<string, number>(),
+  originalData: <any>[],
   data: <any>[],
   selected: new Map(),
   sortState: ref<SortBy>({
@@ -631,9 +636,10 @@ const actions = [
 ];
 
 const handleWebSocketMessage = (event: MessageEvent) => {
-  const data = JSON.parse(event.data);
-  if (data) {
-    fetchRepos();
+  const updatedRepo = JSON.parse(event.data);
+  let i = repos_table.dataMap.get(updatedRepo.id);
+  if (i != undefined) {
+    repos_table.originalData[i] = updatedRepo;
   }
 };
 


### PR DESCRIPTION
## Description

Earlier when we were updating multiple rows, multiple refresh were happening. And also update owner and delete owner were updating the rows one by one, whereas it should happen all at once.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
